### PR TITLE
[Feat] DPR 서버 파일 추가

### DIFF
--- a/dpr_server/encoder.py
+++ b/dpr_server/encoder.py
@@ -1,0 +1,100 @@
+import torch
+from torch import nn
+
+from transformers import (
+    BertModel,
+    BertPreTrainedModel,
+    RobertaModel,
+    RobertaPreTrainedModel,
+    BartModel,
+    BartPretrainedModel,
+    T5Model,
+    T5PreTrainedModel,
+    ElectraPreTrainedModel,
+    ElectraModel,
+    AutoModel,
+    BertConfig,
+)
+
+import transformers
+
+
+class HFBertEncoder(BertModel):
+    def __init__(self, config, project_dim: int = 0):
+        BertModel.__init__(self, config)
+        assert config.hidden_size > 0, "Encoder hidden_size can't be zero"
+        self.encode_proj = (
+            nn.Linear(config.hidden_size, project_dim) if project_dim != 0 else None
+        )
+        self.init_weights()
+
+    @classmethod
+    def init_encoder(
+        cls,
+        cfg_name: str = "klue/bert-base",
+        projection_dim: int = 0,
+        dropout: float = 0.1,
+        pretrained: bool = True,
+    ):
+        cfg = BertConfig.from_pretrained(cfg_name)
+        if dropout != 0:
+            cfg.attention_probs_dropout_prob = dropout
+            cfg.hidden_dropout_prob = dropout
+
+        if pretrained:
+            return cls.from_pretrained(cfg_name, config=cfg, project_dim=projection_dim)
+        else:
+            return HFBertEncoder(cfg, project_dim=projection_dim)
+
+    def forward(
+        self,
+        input_ids,
+        attention_mask=None,
+        token_type_ids=None,
+        representation_token_pos=0,
+    ):
+        out = super().forward(
+            input_ids=input_ids,
+            token_type_ids=token_type_ids,
+            attention_mask=attention_mask,
+        )
+
+        if transformers.__version__.startswith("4") and isinstance(
+            out,
+            transformers.modeling_outputs.BaseModelOutputWithPoolingAndCrossAttentions,
+        ):
+            sequence_output = out.last_hidden_state
+            pooled_output = None
+            hidden_states = out.hidden_states
+
+        elif self.config.output_hidden_states:
+            sequence_output, pooled_output, hidden_states = out
+        else:
+            hidden_states = None
+            out = super().forward(
+                input_ids=input_ids,
+                token_type_ids=token_type_ids,
+                attention_mask=attention_mask,
+            )
+            sequence_output, pooled_output = out
+
+        if isinstance(representation_token_pos, int):
+            pooled_output = sequence_output[:, representation_token_pos, :]
+        else:  # treat as a tensor
+            bsz = sequence_output.size(0)
+            assert (
+                representation_token_pos.size(0) == bsz
+            ), "query bsz={} while representation_token_pos bsz={}".format(
+                bsz, representation_token_pos.size(0)
+            )
+            pooled_output = torch.stack(
+                [
+                    sequence_output[i, representation_token_pos[i, 1], :]
+                    for i in range(bsz)
+                ]
+            )
+
+        if self.encode_proj:
+            pooled_output = self.encode_proj(pooled_output)
+        # return sequence_output, pooled_output, hidden_states
+        return pooled_output

--- a/dpr_server/main.py
+++ b/dpr_server/main.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+from typing import List
+from pydantic import BaseModel
+from model import DenseRetriever
+
+
+class Item(BaseModel):
+    query: str
+    reviews: List[str]
+
+
+app = FastAPI()
+
+DPR = DenseRetriever()
+
+
+@app.get("/dpr/concat")
+def retrieve_concat(item: Item):
+    return {"review": DPR.run_dpr_concat(item.query, item.reviews)}
+
+
+@app.get("/dpr/split")
+def retrieve_split(item: Item):
+    return {"review": DPR.run_dpr_split(item.query, item.reviews)}

--- a/dpr_server/model.py
+++ b/dpr_server/model.py
@@ -1,0 +1,66 @@
+import torch
+import torch.nn.functional as F
+from encoder import HFBertEncoder
+from typing import Callable, Dict, List, Tuple
+from transformers import AutoTokenizer
+
+
+class DenseRetriever:
+    def __init__(self):
+        self.p_encoder = HFBertEncoder.init_encoder(
+            cfg_name="JLake310/bert-p-encoder"
+        ).eval()
+        self.q_encoder = HFBertEncoder.init_encoder(
+            cfg_name="JLake310/bert-q-encoder"
+        ).eval()
+        self.tokenizer = AutoTokenizer.from_pretrained("JLake310/bert-p-encoder")
+
+    def run_dpr_concat(self, query: str, reviews: List[str]) -> str:
+        q_seqs_val = self.tokenizer(
+            [query], padding="max_length", truncation=True, return_tensors="pt"
+        )
+        q_emb = self.q_encoder(**q_seqs_val)
+
+        p_seqs_val = self.tokenizer(
+            reviews, padding="max_length", truncation=True, return_tensors="pt"
+        )
+
+        p_emb = self.p_encoder(**p_seqs_val)
+        sim_scores = torch.matmul(p_emb, torch.transpose(q_emb, 0, 1))
+        max_idx = torch.argmax(sim_scores)
+
+        return reviews[max_idx]
+
+    def run_dpr_split(self, query: str, reviews: List[str]) -> str:
+        q_seqs_val = self.tokenizer(
+            [query], padding="max_length", truncation=True, return_tensors="pt"
+        )
+        q_emb = self.q_encoder(**q_seqs_val)
+
+        max_val = -999
+        max_idx = 0
+        for idx, review in enumerate(reviews):
+            r_tokens = self.tokenizer(
+                review,
+                truncation=True,
+                max_length=512,
+                return_overflowing_tokens=True,
+                return_offsets_mapping=True,
+                return_token_type_ids=True,
+                padding="max_length",
+                return_tensors="pt",
+            )
+            r_input = {
+                "input_ids": r_tokens["input_ids"],
+                "attention_mask": r_tokens["attention_mask"],
+                "token_type_ids": r_tokens["token_type_ids"],
+            }
+            r_emb = self.p_encoder(**r_input)
+            sim_scores = torch.matmul(r_emb, torch.transpose(q_emb, 0, 1))
+            mean_val = torch.mean(sim_scores)
+
+            if mean_val > max_val:
+                max_val = mean_val
+                max_idx = idx
+
+        return reviews[max_idx]


### PR DESCRIPTION
## Overview
- GPU 서버에서 돌릴 DPR API입니다.

## Change Log
- DPR 코드 추가

## To Reviewer
`p_encoder`와 `q_encoder`는 허깅페이스 허브에 업로드 되어있습니다.
Fast API app을 구동할 때 인코더들을 미리 로드해두고 retrieve만 진행합니다.

### 요청 Body
```json
{
  "query": "string",
  "reviews": [
    "string"
  ]
}
```
`query`: 사용자가 입력한 조건
`reviews`: 각 상품의 리뷰들을 join하여 만든 document의 리스트

### 요청 Path
리뷰의 길이를 고려해서 임베딩 점수를 구할 방안을 두 가지로 고안해보았습니다.

`dpr/concat`
reviews 변수로 들어온 리뷰들을 한 번에 토큰화하여 임베딩을 구한 후, 쿼리 임베딩과 곱했을 때 가장 값이 큰 문서를 반환합니다.
위와 같은 방법을 사용할 시 max_length를 넘는 리뷰들은 모두 잘리기 때문에 
각각의 항목에 대해서 임베딩을 구하는 방식도 고안하였습니다.

`dpr/split`
각 document의 길이가 max_length보다 길 것을 감안하여 
반복문으로 각 document들에 대해서 토큰화를 합니다. 이러한 방식으로 overflow 되는 토큰들도 고려할 수 있습니다.
이렇게 토큰화한 document와 쿼리 임베딩을 곱하여 유사도 점수 배열을 얻은 후, 
유사도 점수 배열의 평균값을 그 document의 유사도 점수로 합니다.
모든 document들의 유사도 점수를 구하고 가장 유사도가 큰 문서를 반환합니다.
하지만 그만큼 시간이 오래 걸리기 때문에, 리뷰의 임베딩을 미리 구해두는 등의 모색해보는 것이 좋을 것 같습니다.

### usage
Fast API 앱 시작하기
```bash
uvicorn main:app --port {외부 포트} --host 0.0.0.0
```
GPU 서버를 생성할 때 포트를 할당 받았다면 `aistages -> 서버` 탭에서 외부 포트 번호를 확인할 수 있습니다.
또한 SSH 접속 방법에서 서버의 공인 IP를 확인할 수 있습니다.(118.XX.XXX.XXX 형식)
따라서, API를 요청할 엔드포인트는 `http://118.XX.XXX.XXX:{외부 포트}` 형식이 됩니다.

postman을 사용하여 API 요청 테스트를 할 수 있는데, 
Body에 데이터를 담아 요청을 보내는 방법은 제 블로그 [게시물](https://velog.io/@k0310kjy/FastAPI-FastAPI-%ED%99%9C%EC%9A%A9%ED%95%98%EA%B8%B0)을 참고하시면 될 것 같습니다.


## Issue Tags
- See also: #2 